### PR TITLE
Show max rotation in rates view

### DIFF
--- a/js/plugins/jquery.kiss.rates.chart.js
+++ b/js/plugins/jquery.kiss.rates.chart.js
@@ -127,7 +127,9 @@
                 var text2 = Math.abs(Math.round(rcInputRotation * 100 / 360)) / 100 + " " + data.message + "/sec";
                 context.fillText(text2, width - context.measureText(text2).width - 2, height - 2);
                 context.fillText(data.name, 2, 12);
-                
+                var maxRotationText = "max " + maxRotation + " °/sec";
+                context.fillText(maxRotationText, 2, 24);
+
                 if (Math.abs(maxRotation)>=2000) {
                 	context.fillStyle = "rgba(80,0,0,0.8)";
                     context.fillRect(0, 0, width, height);


### PR DESCRIPTION
This small change will show max rotation per axis without having to connect your TX. Quite useful when tuning your rates.

<img width="416" alt="screenshot 2017-03-07 20 16 12" src="https://cloud.githubusercontent.com/assets/118353/23676166/b45d04a8-0373-11e7-979b-d49553fda48d.png">
