### PR TITLE
Export pretty printed config

### DIFF
--- a/content/configuration.js
+++ b/content/configuration.js
@@ -65,7 +65,7 @@ CONTENT.configuration.initialize = function(callback) {
                             } else {
                                 return v;
                             }
-                        });
+                        }, 2);
                         var blob = new Blob([json], {
                             type: 'text/plain'
                         });


### PR DESCRIPTION
Pretty prints the config backup file (with 2 spaces indent). That way, it's human-readable.